### PR TITLE
fix: Upgrade dependencies to address CVE warnings

### DIFF
--- a/backend/api/src/main/python/Dockerfile
+++ b/backend/api/src/main/python/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3-alpine
 
+# Update Alpine packages to fix OpenSSL CVEs (CVE-2025-9230, CVE-2025-9231, CVE-2025-9232)
+# Requires libssl3 and libcrypto3 >= 3.5.4-r0
+RUN apk update && apk upgrade --no-cache
+
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 

--- a/backend/api/src/main/python/requirements.txt
+++ b/backend/api/src/main/python/requirements.txt
@@ -1,14 +1,18 @@
-connexion[swagger-ui] >= 2.6.0; python_version>="3.6"
-# 2.3 is the last version that supports python 3.4-3.5
-connexion[swagger-ui] <= 2.3.0; python_version=="3.5" or python_version=="3.4"
-# prevent breaking dependencies from advent of connexion>=3.0
-connexion[swagger-ui] <= 2.14.2; python_version>"3.4"
-# connexion requires werkzeug but connexion < 2.4.0 does not install werkzeug
-# we must peg werkzeug versions below to fix connexion
-# https://github.com/zalando/connexion/pull/1044
-werkzeug == 0.16.1; python_version=="3.5" or python_version=="3.4"
+# Connexion 2.x series for OpenAPI spec-driven development
+# Note: Connexion 3.x requires major refactoring (different API structure)
+connexion[swagger-ui] >= 2.6.0, <= 2.14.2
+
+# Core dependencies
 swagger-ui-bundle >= 0.0.2
 python_dateutil >= 2.6.0
 setuptools >= 21.0.0
-Flask == 2.1.1
-flask-cors==4.0.0
+
+# Flask and extensions - upgraded to fix CVE warnings
+# Flask 2.2.5 is highest version compatible with Connexion 2.x (JSONEncoder requirement)
+# Flask 2.3+ removed JSONEncoder which breaks Connexion 2.14.x
+# Note: CVE-2023-30861 (Flask <2.3.2) is low severity and acceptable for Connexion compatibility
+Flask >= 2.2.5, < 2.3.0
+
+# Flask-CORS 5.0.0 fixes CVE-2024-6221 and is compatible with Flask 2.2.x
+# Flask-CORS 6.0.x requires Flask 3.0+, incompatible with Connexion 2.x
+flask-cors >= 5.0.0, < 6.0.0


### PR DESCRIPTION
## Summary
Upgrades Python dependencies and Docker base image to address CVE warnings while maintaining Connexion 2.x compatibility.

## CVEs Addressed
- **CVE-2025-9230, CVE-2025-9231, CVE-2025-9232** (OpenSSL): Fixed via Alpine package upgrade to libssl3/libcrypto3 3.5.4-r0
- **CVE-2024-6221** (Flask-CORS): Upgraded from 4.0.x to 5.0.1

## Changes Made

### Dockerfile
- Added `apk update && apk upgrade --no-cache` to automatically update Alpine packages
- Fixes OpenSSL CVEs in base image

### requirements.txt
- **Flask**: Upgraded to 2.2.5 (highest version compatible with Connexion 2.14.x)
- **Flask-CORS**: Upgraded to 5.0.1 (compatible with Flask 2.2.x, fixes CVE-2024-6221)
- Added detailed comments explaining version constraints

## Compatibility Notes
- Flask 2.3+ removed JSONEncoder, which Connexion 2.14.x depends on
- Maintained Flask 2.2.5 to preserve Connexion compatibility
- Accepted CVE-2023-30861 (Flask <2.3.2, low severity) as acceptable trade-off
- Alternative: Upgrade to Connexion 3.x would require major refactoring

## Testing Performed
- ✅ Docker image builds successfully
- ✅ Package imports verified (Flask 2.2.5, Connexion 2.14.2, Flask-CORS 5.0.1)
- ✅ API endpoints responding correctly (/animal, /ui/)
- ✅ Swagger UI functional

## CVEs Still Open
- **pip CVE-2025-8869**: No fixed version available yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)